### PR TITLE
Fix numeric comparison in evaluate

### DIFF
--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -304,7 +304,7 @@ export function evaluate(
         );
         return false;
       }
-      return fieldValue > value;
+      return Number(fieldValue) > Number(value);
     case "LT":
       if (isNaN(Number(fieldValue)) || isNaN(Number(value))) {
         console.error(
@@ -312,7 +312,7 @@ export function evaluate(
         );
         return false;
       }
-      return fieldValue < value;
+      return Number(fieldValue) < Number(value);
     case "AFTER":
     case "BEFORE": {
       // more/less than `value` days ago

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -381,10 +381,12 @@ describe("operator evaluation", () => {
     ["value", "GT", "value", false],
     ["value", "GT", "0", false],
     ["1", "GT", "0", true],
+    ["2", "GT", "10", false],
 
     ["value", "LT", "value", false],
     ["value", "LT", "0", false],
     ["0", "LT", "1", true],
+    ["2", "LT", "10", true],
 
     ["start VALUE end", "CONTAINS", "value", true],
     ["alue", "CONTAINS", "value", false],


### PR DESCRIPTION
## Summary
- fix numeric comparison for GT/LT operators
- test numeric comparison edge cases

## Testing
- `yarn workspace @bucketco/flag-evaluation test`
- `yarn workspace @bucketco/node-sdk test`


------
https://chatgpt.com/codex/tasks/task_e_68528e0656ac832abcb2e44d41a903f4